### PR TITLE
ci: Add Serverpod code generation step to deploy workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -56,6 +56,13 @@ jobs:
         working-directory: rmotly_server
         run: dart pub get
 
+      - name: Install Serverpod CLI
+        run: dart pub global activate serverpod_cli
+
+      - name: Generate Serverpod code
+        working-directory: rmotly_server
+        run: dart pub global run serverpod_cli:serverpod generate
+
       - name: Analyze code
         working-directory: rmotly_server
         run: dart analyze


### PR DESCRIPTION
## Summary
- Adds Serverpod CLI installation and code generation step to the dev deployment workflow
- The generated files are gitignored, so CI needs to generate them before analysis/tests

## Test plan
- [ ] Verify workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)