### PR TITLE
ci: Fix serverpod generate command

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Generate Serverpod code
         working-directory: rmotly_server
-        run: dart pub global run serverpod_cli:serverpod generate
+        run: serverpod generate
 
       - name: Analyze code
         working-directory: rmotly_server


### PR DESCRIPTION
## Summary
- Fix serverpod generate command to use `serverpod generate` instead of `dart pub global run serverpod_cli:serverpod generate`
- The newer CLI doesn't expose the bin/serverpod.dart path

## Test plan
- [ ] Verify workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)