### PR TITLE
ci: Use Flutter instead of Dart for serverpod generate

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -40,10 +40,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
         with:
-          sdk: '3.6.2'
+          flutter-version: '3.27.4'
+          channel: 'stable'
 
       - name: Cache pub dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Serverpod CLI requires Flutter to be installed, not just Dart SDK
- Updated workflow to use flutter-action instead of setup-dart

## Test plan
- [ ] Verify workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)