### PR TITLE
fix: Resolve code analysis errors blocking CI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,15 +10,80 @@ env:
   DEV_USER: cicd
 
 jobs:
-  # TODO: Re-enable tests once code issues are fixed:
-  # - event_service.dart:213 - greaterThan not defined for ColumnDateTime
-  # - notification_service.dart:156 - StreamNotification not defined
-  # - sse_route.dart:10 - Missing Route.handleCall implementation
-  # - webhook_route.dart:10 - Missing Route.handleCall implementation
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rmotly_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.27.4'
+          channel: 'stable'
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        working-directory: rmotly_server
+        run: dart pub get
+
+      - name: Install Serverpod CLI
+        run: dart pub global activate serverpod_cli
+
+      - name: Generate Serverpod code
+        working-directory: rmotly_server
+        run: serverpod generate
+
+      - name: Analyze code
+        working-directory: rmotly_server
+        run: dart analyze
+
+      - name: Run tests
+        working-directory: rmotly_server
+        run: dart test
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rmotly_test
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
 
   deploy:
     name: Deploy to Dev Server
     runs-on: ubuntu-latest
+    needs: test
     environment:
       name: development
       url: https://dev1.ht2.io

--- a/rmotly_server/lib/src/services/event_service.dart
+++ b/rmotly_server/lib/src/services/event_service.dart
@@ -210,7 +210,7 @@ class EventService {
           condition = condition & t.eventType.equals(eventType);
         }
         if (since != null) {
-          condition = condition & t.timestamp.greaterThan(since);
+          condition = condition & (t.timestamp > since);
         }
         return condition;
       },

--- a/rmotly_server/lib/src/services/notification_service.dart
+++ b/rmotly_server/lib/src/services/notification_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:serverpod/serverpod.dart';
 
+import '../generated/protocol.dart';
 import 'notification_stream_service.dart';
 import 'push_service.dart';
 

--- a/rmotly_server/lib/src/web/routes/sse_route.dart
+++ b/rmotly_server/lib/src/web/routes/sse_route.dart
@@ -5,7 +5,7 @@ import 'package:serverpod/serverpod.dart';
 import '../../endpoints/sse_endpoint.dart';
 
 /// Route handler for SSE endpoint
-/// 
+///
 /// Handles GET /api/sse/notifications
 class SseRoute extends Route {
   final Serverpod pod;
@@ -15,7 +15,9 @@ class SseRoute extends Route {
     _handler = SseHandler(pod);
   }
 
-  Future<void> handleRequest(HttpRequest request) async {
+  @override
+  Future<bool> handleCall(Session session, HttpRequest request) async {
     await _handler.handleRequest(request);
+    return true;
   }
 }

--- a/rmotly_server/lib/src/web/routes/webhook_route.dart
+++ b/rmotly_server/lib/src/web/routes/webhook_route.dart
@@ -5,32 +5,34 @@ import 'package:serverpod/serverpod.dart';
 import '../../endpoints/webhook_endpoint.dart';
 
 /// Route handler for webhook endpoint
-/// 
+///
 /// Handles POST /api/notify/:topicId
 class WebhookRoute extends Route {
   final Serverpod pod;
   late final WebhookHandler _handler;
 
-  WebhookRoute(this.pod) {
+  WebhookRoute(this.pod) : super(method: RouteMethod.post) {
     _handler = WebhookHandler(pod);
   }
 
-  Future<void> handleRequest(HttpRequest request) async {
+  @override
+  Future<bool> handleCall(Session session, HttpRequest request) async {
     // Extract topic ID from path
     final uri = request.uri;
     final pathSegments = uri.pathSegments;
-    
+
     // Path should be: api/notify/:topicId
-    if (pathSegments.length != 3 || 
-        pathSegments[0] != 'api' || 
+    if (pathSegments.length != 3 ||
+        pathSegments[0] != 'api' ||
         pathSegments[1] != 'notify') {
       request.response.statusCode = HttpStatus.notFound;
       request.response.write('Not found');
       await request.response.close();
-      return;
+      return true;
     }
-    
+
     final topicId = pathSegments[2];
     await _handler.handleRequest(request, topicId);
+    return true;
   }
 }


### PR DESCRIPTION
## Summary
Fixes 4 code analysis errors that were blocking CI:

- **event_service.dart:213** - Use `>` operator instead of `.greaterThan()` for DateTime comparison
- **notification_service.dart** - Add missing import for `StreamNotification` from generated protocol
- **sse_route.dart** - Implement `handleCall` method required by Serverpod's `Route` abstract class
- **webhook_route.dart** - Implement `handleCall` method required by Serverpod's `Route` abstract class

Also re-enables tests in the dev deploy workflow.

## Test plan
- [ ] CI tests pass
- [ ] Deployment succeeds after tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)