### PR TITLE
fix: Remove unused imports and variables to fix warnings

### DIFF
--- a/rmotly_server/lib/src/endpoints/notification_stream_endpoint.dart
+++ b/rmotly_server/lib/src/endpoints/notification_stream_endpoint.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:serverpod/serverpod.dart';
-import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 
 import '../services/notification_stream_service.dart';
 import '../generated/protocol.dart';

--- a/rmotly_server/lib/src/services/notification_stream_service.dart
+++ b/rmotly_server/lib/src/services/notification_stream_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:serverpod/serverpod.dart';
 
@@ -34,9 +33,6 @@ class _UserConnection {
 class NotificationStreamService {
   /// Map of userId -> list of active connections
   final Map<int, List<_UserConnection>> _connections = {};
-
-  /// Lock for thread-safe connection management
-  final _lock = Object();
 
   /// Total active connections
   int get totalConnections =>

--- a/rmotly_server/lib/src/services/push_service.dart
+++ b/rmotly_server/lib/src/services/push_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:serverpod/serverpod.dart';
@@ -278,8 +277,7 @@ class PushService {
     //
     // For now, we return a simplified version that works with ntfy
     // The full WebPush implementation requires the web_push package
-
-    final origin = '${endpoint.scheme}://${endpoint.host}';
+    // TODO: Use endpoint origin for JWT audience when implementing full VAPID
 
     // Placeholder - actual JWT creation requires crypto libraries
     // In production, use the web_push package for proper VAPID signing


### PR DESCRIPTION
## Summary
Fixes remaining analyzer warnings:

- `notification_stream_endpoint.dart` - Remove unused `serverpod_auth_server` import
- `notification_stream_service.dart` - Remove unused `dart:convert` import and `_lock` field
- `push_service.dart` - Remove unused `dart:math` import and `origin` variable

## Test plan
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)