### PR TITLE
ci: Add passwords.yaml creation step for tests

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -64,6 +64,15 @@ jobs:
         working-directory: rmotly_server
         run: serverpod generate
 
+      - name: Create test passwords file
+        working-directory: rmotly_server
+        run: |
+          cat > config/passwords.yaml << 'EOF'
+          shared:
+          test:
+            database: 'postgres'
+          EOF
+
       - name: Analyze code
         working-directory: rmotly_server
         run: dart analyze


### PR DESCRIPTION
## Summary
Tests require a `config/passwords.yaml` file with database credentials.
Create it during CI with the test database password matching the postgres service.

## Test plan
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)