### PR TITLE
ci: Add release workflow with client packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,296 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  FLUTTER_VERSION: '3.27.4'
+
+jobs:
+  # Build Android APK
+  build-android:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Install dependencies
+        working-directory: rmotly_app
+        run: flutter pub get
+
+      - name: Build APK
+        working-directory: rmotly_app
+        run: flutter build apk --release
+
+      - name: Rename APK with version
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          mv rmotly_app/build/app/outputs/flutter-apk/app-release.apk "rmotly_app/build/app/outputs/flutter-apk/rmotly-${VERSION}-android.apk"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: rmotly_app/build/app/outputs/flutter-apk/rmotly-*-android.apk
+
+  # Build Web App
+  build-web:
+    name: Build Web App
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        working-directory: rmotly_app
+        run: flutter pub get
+
+      - name: Build Web
+        working-directory: rmotly_app
+        run: flutter build web --release
+
+      - name: Create Web archive
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cd rmotly_app/build
+          tar -czf "rmotly-${VERSION}-web.tar.gz" web
+          zip -r "rmotly-${VERSION}-web.zip" web
+
+      - name: Upload Web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: |
+            rmotly_app/build/rmotly-*-web.tar.gz
+            rmotly_app/build/rmotly-*-web.zip
+
+  # Build Server Binary
+  build-server:
+    name: Build Server Binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        working-directory: rmotly_server
+        run: dart pub get
+
+      - name: Install Serverpod CLI
+        run: dart pub global activate serverpod_cli
+
+      - name: Generate Serverpod code
+        working-directory: rmotly_server
+        run: serverpod generate
+
+      - name: Compile server
+        working-directory: rmotly_server
+        run: dart compile exe bin/main.dart -o bin/server
+
+      - name: Create server package
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          mkdir -p release-package
+          cp rmotly_server/bin/server release-package/
+          cp -r rmotly_server/config release-package/
+          cp -r rmotly_server/migrations release-package/
+          cp rmotly_server/docker-compose.yaml release-package/ 2>/dev/null || true
+          cp rmotly_server/Dockerfile release-package/ 2>/dev/null || true
+          cp -r rmotly_server/scripts release-package/ 2>/dev/null || true
+          tar -czf "rmotly-${VERSION}-server-linux-x64.tar.gz" -C release-package .
+
+      - name: Upload Server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-binary
+          path: rmotly-*-server-linux-x64.tar.gz
+
+  # Package Dart Client
+  build-client-package:
+    name: Build Dart Client Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        working-directory: rmotly_client
+        run: dart pub get
+
+      - name: Analyze client package
+        working-directory: rmotly_client
+        run: dart analyze
+
+      - name: Create client package archive
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          tar -czf "rmotly-${VERSION}-client-dart.tar.gz" \
+            --exclude='.dart_tool' \
+            --exclude='.packages' \
+            --exclude='pubspec.lock' \
+            rmotly_client
+
+      - name: Upload Client artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: client-package
+          path: rmotly-*-client-dart.tar.gz
+
+  # Create GitHub Release
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-android, build-web, build-server, build-client-package]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Display artifacts
+        run: |
+          echo "Downloaded artifacts:"
+          find artifacts -type f -name "*"
+
+      - name: Generate release notes
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cat << EOF > release_notes.md
+          ## Rmotly ${VERSION}
+
+          ### Downloads
+
+          | Platform | File | Description |
+          |----------|------|-------------|
+          | Android | rmotly-${VERSION}-android.apk | Android application |
+          | Web | rmotly-${VERSION}-web.zip | Web application (zip) |
+          | Web | rmotly-${VERSION}-web.tar.gz | Web application (tar.gz) |
+          | Server | rmotly-${VERSION}-server-linux-x64.tar.gz | Server binary with configs |
+          | Dart Client | rmotly-${VERSION}-client-dart.tar.gz | Dart/Flutter client package |
+
+          ### Installation
+
+          #### Android
+          Download and install the APK on your Android device.
+
+          #### Web
+          Extract the web archive and serve with any static file server:
+          \`\`\`bash
+          tar -xzf rmotly-${VERSION}-web.tar.gz
+          cd web && python -m http.server 8080
+          \`\`\`
+
+          #### Server
+          \`\`\`bash
+          tar -xzf rmotly-${VERSION}-server-linux-x64.tar.gz
+          # Configure config/passwords.yaml
+          ./server --mode production
+          \`\`\`
+
+          #### Dart Client Package
+          Add to your pubspec.yaml:
+          \`\`\`yaml
+          dependencies:
+            rmotly_client:
+              path: ./rmotly_client
+          \`\`\`
+
+          ---
+          Generated with [Claude Code](https://claude.com/claude-code)
+          EOF
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Rmotly ${{ github.ref_name }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
+          files: |
+            artifacts/android-apk/*
+            artifacts/web-build/*
+            artifacts/server-binary/*
+            artifacts/client-package/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow triggered by version tags (`v*`)
- Builds and packages all client artifacts for releases

## Artifacts Built
| Artifact | Description |
|----------|-------------|
| `rmotly-{version}-android.apk` | Android application |
| `rmotly-{version}-web.zip` | Web application (zip archive) |
| `rmotly-{version}-web.tar.gz` | Web application (tarball) |
| `rmotly-{version}-server-linux-x64.tar.gz` | Server binary with configs |
| `rmotly-{version}-client-dart.tar.gz` | Dart client package |

## Usage
To create a release:
```bash
git tag v0.2.0
git push origin v0.2.0
```

The workflow will automatically:
1. Build all client packages in parallel
2. Create a GitHub release with generated notes
3. Attach all artifacts to the release
4. Mark as prerelease if tag contains `-alpha`, `-beta`, or `-rc`

## Test plan
- [x] Workflow syntax is valid
- [ ] Merge and create tag `v0.1.1` to test the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)