### PR TITLE
fix: Release workflow - upgrade Flutter and fix server compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  FLUTTER_VERSION: '3.27.4'
+  FLUTTER_VERSION: '3.29.0'
 
 jobs:
   # Build Android APK
@@ -146,8 +146,9 @@ jobs:
         run: serverpod generate
 
       - name: Compile server
-        working-directory: rmotly_server
-        run: dart compile exe bin/main.dart -o bin/server
+        run: |
+          cd rmotly_server
+          dart compile exe bin/main.dart -o bin/server
 
       - name: Create server package
         env:


### PR DESCRIPTION
## Summary
- Upgrade Flutter from 3.27.4 to 3.29.0 to fix `toARGB32` method compatibility issue with `image_cropper_platform_interface`
- Use explicit `cd` command for server compile step as workaround for `working-directory` not being applied

## Test plan
- [ ] Merge and create a new tag (v0.1.2) to trigger the release workflow
- [ ] Verify all build jobs complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)