### PR TITLE
fix: Add server main.dart entry point to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -566,6 +566,10 @@ app.*.symbols
 **/config/passwords.yaml
 **/config/production.yaml
 
+# Dart bin directory - source files (not compiled binaries)
+!rmotly_server/bin/
+!rmotly_server/bin/*.dart
+
 # Database
 *.db
 *.sqlite

--- a/rmotly_server/bin/main.dart
+++ b/rmotly_server/bin/main.dart
@@ -1,0 +1,7 @@
+import 'package:rmotly_server/server.dart';
+
+/// This is the starting point for your Serverpod server. Typically, there is
+/// no need to modify this file.
+void main(List<String> args) {
+  run(args);
+}


### PR DESCRIPTION
## Summary
- Added `rmotly_server/bin/main.dart` which was missing from git
- Updated `.gitignore` to allow Dart source files in `rmotly_server/bin/`
- The `[Bb]in/` pattern was excluding the Dart server entry point

This fixes the release workflow "Compile server" step that was failing with "bin/main.dart" file not found.

## Test plan
- [ ] Merge and create a new tag (v0.1.3) to trigger the release workflow
- [ ] Verify the Server Binary build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)