### PR TITLE
feat: Add Docker image deployment to GitHub Container Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 env:
   FLUTTER_VERSION: '3.29.0'
@@ -214,11 +215,50 @@ jobs:
           name: client-package
           path: rmotly-*-client-dart.tar.gz
 
+  # Build and Push Docker Image
+  build-docker:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/rmotly-server
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./rmotly_server
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
   # Create GitHub Release
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-android, build-web, build-server, build-client-package]
+    needs: [build-android, build-web, build-server, build-client-package, build-docker]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -248,6 +288,7 @@ jobs:
           | Web | rmotly-${VERSION}-web.zip | Web application (zip) |
           | Web | rmotly-${VERSION}-web.tar.gz | Web application (tar.gz) |
           | Server | rmotly-${VERSION}-server-linux-x64.tar.gz | Server binary with configs |
+          | Docker | ghcr.io/ht2-io/rmotly-server:${VERSION#v} | Server Docker image |
           | Dart Client | rmotly-${VERSION}-client-dart.tar.gz | Dart/Flutter client package |
 
           ### Installation
@@ -267,6 +308,14 @@ jobs:
           tar -xzf rmotly-${VERSION}-server-linux-x64.tar.gz
           # Configure config/passwords.yaml
           ./server --mode production
+          \`\`\`
+
+          #### Docker
+          \`\`\`bash
+          docker pull ghcr.io/ht2-io/rmotly-server:${VERSION#v}
+          docker run -p 8080:8080 -p 8081:8081 -p 8082:8082 \\
+            -v /path/to/config:/app/config \\
+            ghcr.io/ht2-io/rmotly-server:${VERSION#v}
           \`\`\`
 
           #### Dart Client Package

--- a/rmotly_server/Dockerfile
+++ b/rmotly_server/Dockerfile
@@ -22,6 +22,7 @@ FROM debian:bookworm-slim
 # Install required runtime libraries
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Add `build-docker` job to release workflow that builds and pushes the server Docker image to ghcr.io
- Images are tagged with semantic version (e.g., `0.1.4`, `0.1`, `latest`)
- Updated release notes to include Docker pull/run instructions
- Added `curl` to Dockerfile for health check support

## Docker Image
After merging, releases will publish to:
```
ghcr.io/ht2-io/rmotly-server:<version>
```

## Test plan
- [ ] Merge and create a new tag (v0.1.4) to trigger the release workflow
- [ ] Verify Docker image is pushed to ghcr.io
- [ ] Verify image can be pulled and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)