### PR TITLE
fix: Move Dockerfile to repo root for serverpod generate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./rmotly_server
+          context: .
+          file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# Dockerfile for rmotly-server
+# Build context should be the repository root
+
+# Build stage
+FROM dart:3.6.2 AS build
+WORKDIR /app
+
+# Copy the entire project for serverpod generate
+COPY rmotly_server/ ./rmotly_server/
+COPY rmotly_client/ ./rmotly_client/
+
+WORKDIR /app/rmotly_server
+
+# Get dependencies
+RUN dart pub get
+
+# Generate Serverpod code
+RUN dart pub global activate serverpod_cli
+RUN dart pub global run serverpod_cli generate
+
+# Compile the server executable
+RUN dart compile exe bin/main.dart -o bin/server
+
+# Final stage
+FROM debian:bookworm-slim
+
+# Install required runtime libraries
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Environment variables
+ENV runmode=production
+ENV serverid=default
+ENV logging=normal
+ENV role=monolith
+
+# Copy compiled server executable
+COPY --from=build /app/rmotly_server/bin/server /app/server
+
+# Copy configuration files and resources
+COPY --from=build /app/rmotly_server/config/ /app/config/
+COPY --from=build /app/rmotly_server/web/ /app/web/
+COPY --from=build /app/rmotly_server/migrations/ /app/migrations/
+
+# This file is required to enable the endpoint log filter in Insights.
+COPY --from=build /app/rmotly_server/lib/src/generated/protocol.yaml /app/lib/src/generated/protocol.yaml
+
+# Expose ports
+# 8080 - API server
+# 8081 - Insights server
+# 8082 - Web server
+EXPOSE 8080
+EXPOSE 8081
+EXPOSE 8082
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8080/ || exit 1
+
+# Define the entrypoint command
+ENTRYPOINT ["/app/server"]
+CMD ["--mode", "production", "--server-id", "default", "--logging", "normal", "--role", "monolith"]


### PR DESCRIPTION
## Summary
The Docker build failed because `serverpod generate` needs access to both `rmotly_server` and `rmotly_client` directories.

- Create Dockerfile at repo root with proper context
- Update workflow to use repo root as build context  
- Copy both server and client directories in build stage

## Test plan
- [ ] Merge and create a new tag (v0.1.5) to trigger the release workflow
- [ ] Verify Docker image builds successfully
- [ ] Verify image is pushed to ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)