### PR TITLE
fix: Use Flutter base image for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Dockerfile for rmotly-server
 # Build context should be the repository root
 
-# Build stage
-FROM dart:3.6.2 AS build
+# Build stage - using Flutter image since serverpod generate requires Flutter
+FROM ghcr.io/cirruslabs/flutter:3.29.0 AS build
 WORKDIR /app
 
 # Copy the entire project for serverpod generate
@@ -16,7 +16,8 @@ RUN dart pub get
 
 # Generate Serverpod code
 RUN dart pub global activate serverpod_cli
-RUN dart pub global run serverpod_cli generate
+ENV PATH="$PATH:/root/.pub-cache/bin"
+RUN serverpod generate
 
 # Compile the server executable
 RUN dart compile exe bin/main.dart -o bin/server


### PR DESCRIPTION
## Summary
- Changed Docker base image from `dart:3.6.2` to `ghcr.io/cirruslabs/flutter:3.29.0`
- `serverpod generate` requires Flutter to be installed, not just Dart
- Added PATH environment variable for serverpod CLI

## Test plan
- [ ] Docker build succeeds with Flutter base image
- [ ] Docker image is pushed to ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)