### PR TITLE
fix(api): Include eventType and controlId in action execution parameters

### DIFF
--- a/rmotly_server/lib/src/endpoints/event_endpoint.dart
+++ b/rmotly_server/lib/src/endpoints/event_endpoint.dart
@@ -76,17 +76,7 @@ class EventEndpoint extends Endpoint {
       timestamp: DateTime.now(),
     );
 
-    session.log(
-      'DEBUG: Creating event with eventType="$eventType" (before insert)',
-      level: LogLevel.info,
-    );
-
     final savedEvent = await Event.db.insertRow(session, event);
-
-    session.log(
-      'DEBUG: Saved event has eventType="${savedEvent.eventType}" (after insert)',
-      level: LogLevel.info,
-    );
 
     session.log(
       'Event created: ${savedEvent.id} - $eventType from $sourceType:$sourceId',

--- a/rmotly_server/lib/src/services/event_service.dart
+++ b/rmotly_server/lib/src/services/event_service.dart
@@ -120,11 +120,15 @@ class EventService {
       return null;
     }
 
-    // Parse payload parameters
-    Map<String, dynamic>? parameters;
+    // Parse payload parameters and add event metadata
+    Map<String, dynamic> parameters = {
+      'eventType': eventType,
+      'controlId': controlId,
+    };
     if (payload != null && payload.isNotEmpty) {
       try {
-        parameters = jsonDecode(payload) as Map<String, dynamic>;
+        final payloadMap = jsonDecode(payload) as Map<String, dynamic>;
+        parameters.addAll(payloadMap);
       } catch (e) {
         session.log(
           'Failed to parse event payload: $e',


### PR DESCRIPTION
## Summary

The template variable substitution for action body templates was failing because `eventType` and `controlId` were not included in the parameters map passed to the action executor.

## Root Cause

In `event_service.dart`, the `_processControlEvent` method was only passing the parsed payload JSON as parameters to the action executor. Template variables like `{{eventType}}` weren't being substituted because `eventType` wasn't in the parameters map.

## Fix

Now `eventType` and `controlId` are always included in the parameters map:

```dart
Map<String, dynamic> parameters = {
  'eventType': eventType,
  'controlId': controlId,
};
if (payload != null && payload.isNotEmpty) {
  final payloadMap = jsonDecode(payload) as Map<String, dynamic>;
  parameters.addAll(payloadMap);
}
```

## Test Plan

- [x] Integration test `when control is triggered then action executes and result is recorded` should now pass
- [x] Template variable `{{eventType}}` should resolve to the actual event type (e.g., 'button_press')

Closes #230